### PR TITLE
Fix undefined behavior with empty vectors

### DIFF
--- a/quantiles.h
+++ b/quantiles.h
@@ -25,6 +25,6 @@ T quantile(const T* d, const uint size, F q) {
 
 template <class T, class F>
 inline T quantile(const std::vector<T>& v, F q)
-  { return quantile(&v[0], v.size(), q); }
+  { return quantile(v.data(), v.size(), q); }
 
 #endif  // QUANTILES_H_

--- a/ranker.h
+++ b/ranker.h
@@ -17,7 +17,7 @@ class ranker {
   std::function<bool(const T&, const T&)> comp;
 
  public:
-  explicit ranker(const vector<T>& v) : p(&v[0]), sz(v.size()), comp(C()) { }
+  explicit ranker(const vector<T>& v) : p(v.data()), sz(v.size()), comp(C()) { }
   ranker(const T* tp, uint_least64_t s) : p(tp), sz(s), comp(C()) { }
 
   int operator()(uint_least64_t i1, uint_least64_t i2) const {

--- a/ranker.h
+++ b/ranker.h
@@ -2,7 +2,9 @@
 #define RANKER_H_
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
+#include <numeric>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Replace unsafe &v[0] with v.data() in vector constructors/wrappers. Using &v[0] on an empty vector is undefined behavior as it attempts to access a non-existent element. The v.data() method is safe for empty vectors and returns a valid (though non-dereferenceable) pointer.

Changes:
- ranker.h:20: Constructor now uses v.data() instead of &v[0]
- quantiles.h:28: Wrapper function now uses v.data() instead of &v[0]

This fix ensures the code is standards-compliant and avoids potential crashes when instantiating ranker or calling quantile with empty vectors.