### PR TITLE
Fix quantile edge cases and remove std::function overhead from ranker

### DIFF
--- a/quantiles.h
+++ b/quantiles.h
@@ -1,12 +1,13 @@
 #ifndef QUANTILES_H_
 #define QUANTILES_H_
 
+#include <cstddef>
 #include <vector>
 #include <algorithm>
 
 // Return a quantile 'q' of an array 'd' of size 'size'
 template <class T, class F>  // T = numeric type, F = floating point type
-T quantile(const T* d, const uint size, F q) {
+T quantile(const T* d, const std::size_t size, F q) {
   // Edge cases
   if (size == 0) return 0;
   if (size == 1) return d[0];
@@ -14,11 +15,15 @@ T quantile(const T* d, const uint size, F q) {
   if (q >= 1) return *std::max_element(d, d + size);
 
   F float_ind = (size - 1) * q;
-  uint ind = uint(float_ind);
+  std::size_t ind = std::size_t(float_ind);
+  // Floating-point rounding can push float_ind up to size - 1 even
+  // though q < 1, which would make the i2 range below empty.
+  if (ind >= size - 1) return *std::max_element(d, d + size);
   F delta = float_ind - ind;
   std::vector<T> dcopy(d, d + size);
   std::nth_element(dcopy.begin(), dcopy.begin() + ind, dcopy.end());
   T i1 = *(dcopy.begin() + ind);
+  if (delta <= 0) return i1;
   T i2 = *std::min_element(dcopy.begin() + ind + 1, dcopy.end());
   return i1 * (1.0 - delta) + i2 * delta;  // Any value in [i1, i2] is valid.
 }

--- a/ranker.h
+++ b/ranker.h
@@ -16,13 +16,13 @@ class ranker {
  private:
   const T* p;
   uint_least64_t sz;
-  std::function<bool(const T&, const T&)> comp;
+  C comp;
 
  public:
-  explicit ranker(const vector<T>& v) : p(v.data()), sz(v.size()), comp(C()) { }
-  ranker(const T* tp, uint_least64_t s) : p(tp), sz(s), comp(C()) { }
+  explicit ranker(const vector<T>& v) : p(v.data()), sz(v.size()), comp() { }
+  ranker(const T* tp, uint_least64_t s) : p(tp), sz(s), comp() { }
 
-  int operator()(uint_least64_t i1, uint_least64_t i2) const {
+  bool operator()(uint_least64_t i1, uint_least64_t i2) const {
     return comp(p[i1], p[i2]);
   }
 


### PR DESCRIPTION
Follow-up fixes from a correctness/efficiency review of `ranker.h` and `quantiles.h`.

## ranker.h

- **Store the comparator as its template type `C` instead of `std::function`.** The type-erased `std::function` member made every comparison inside `std::sort`/`std::partial_sort` an opaque indirect call the compiler can't inline — typically a 2–3x slowdown on the sort, which dominates the cost of ranking. `C` is already a template parameter, so type erasure bought nothing.
- `operator()` now returns `bool` (was `int`).

## quantiles.h

- **Replace the non-standard `uint` with `std::size_t`.** `uint` is a POSIX typedef that happens to leak in through glibc/macOS headers but fails to compile on MSVC, and as a 32-bit type it silently narrowed `v.size()`.
- **Fix an undefined-behavior edge case.** The code assumed `q < 1` implies `ind <= size - 2`, but floating-point rounding (e.g. `F = float` with large `size`) can make `(size - 1) * q` evaluate to exactly `size - 1`. The `min_element` range for `i2` was then empty, and dereferencing its result is UB. Now guarded by returning the max element in that case.
- **Skip the `i2` scan when the quantile lands exactly on an index.** With `delta == 0` the interpolation returns `i1` regardless, so the O(n) `min_element` pass was wasted work.

## Testing

Bazel/gtest aren't available in this sandbox, so verification was a standalone test compiled with both `g++` and `clang++` (`-std=c++17 -O2 -Wall -Wextra`) covering: the exact assertions from the existing `rank`/`order`/`partial_*` test suites, plus quantile cases for exact-index hits, interpolation (including integer `T`), `q <= 0` / `q >= 1`, and empty/single-element inputs. All pass. The existing `bazel test :all` suite should be run to confirm.

https://claude.ai/code/session_01W1FMTv3uDyjU4KhUzvVUTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1FMTv3uDyjU4KhUzvVUTf)_